### PR TITLE
Add Visual Stack and Queue Displays using Dfs adn Bfs 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@angular/router": "^18.2.0",
         "@netlify/angular-runtime": "^2.1.0",
         "ace-builds": "^1.36.2",
+        "axios": "^1.7.7",
         "chart.js": "^4.4.5",
         "eccom-prj": "file:",
         "express-validator": "^7.2.0",
@@ -5303,6 +5304,12 @@
         "lodash": "^4.17.14"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -5339,6 +5346,17 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-loader": {
@@ -6090,6 +6108,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -6708,6 +6738,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -7644,7 +7683,6 @@
       "version": "1.15.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
       "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -7676,6 +7714,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -10159,7 +10211,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -10169,7 +10220,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -11833,6 +11883,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/prr": {
       "version": "1.0.1",

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -23,6 +23,7 @@ import { GeminibotComponent } from './components/geminibot/geminibot.component';
 import { AlgorithmComparisonComponent } from './components/algocompare/algocompare.component';
 
 import { ProfileDashboardPageComponent } from './components/profile/profile.component';
+import { VisualStackQueueComponent } from './components/visual-stack-queue/visual-stack-queue.component';
 
 export const routes: Routes = [
   {
@@ -100,6 +101,10 @@ export const routes: Routes = [
   {
     path: 'gemini',
     component: GeminibotComponent,
+  },
+  {
+    path: 'visual-stack',
+    component: VisualStackQueueComponent,
   },
   // {
   //   path: 'algo-compare',

--- a/src/app/components/visual-stack-queue/visual-stack-queue.component.css
+++ b/src/app/components/visual-stack-queue/visual-stack-queue.component.css
@@ -1,0 +1,117 @@
+
+.stack-container, .queue-container {
+    margin: 20px;
+    padding: 20px;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    background-color: #f8f8f8;
+    }
+    
+    .stack-item, .queue-item {
+    padding: 10px;
+    margin: 5px;
+    background-color: #ffce54;
+    border-radius: 4px;
+    text-align: center;
+    font-weight: bold;
+    }
+    
+    button {
+    margin: 10px;
+    padding: 10px;
+    background-color: #5cb85c;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    }
+    
+    button:hover {
+    background-color: #4cae4c;
+    }
+    /* visual-stack-queue.component.css */
+.container {
+    text-align: center;
+    padding: 20px;
+    margin-top: 10rem;
+}
+
+.title h1 {
+    font-size: 2em;
+    margin-bottom: 20px;
+}
+
+.visual-container {
+    display: flex;
+    justify-content: space-around;
+    align-items: flex-start;
+    flex-wrap: wrap;
+}
+
+.stack-container, .queue-container {
+    width: 45%;
+    margin: 20px;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    background-color: #f9f9f9;
+}
+
+.stack h3, .queue h3 {
+    font-size: 1.5em;
+    margin-bottom: 15px;
+    color: #333;
+}
+
+.stack, .queue {
+    min-height: 200px;
+    border: 2px dashed #ccc;
+    padding: 10px;
+    margin-bottom: 20px;
+    border-radius: 8px;
+}
+
+.stack-item, .queue-item {
+    margin: 5px 0;
+    padding: 10px;
+    background-color: #e3f2fd;
+    border-radius: 5px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    transition: transform 0.3s ease;
+}
+
+.stack-item:hover, .queue-item:hover {
+    transform: scale(1.05);
+}
+
+.button-group {
+    display: flex;
+    justify-content: space-around;
+}
+
+.btn {
+    padding: 10px 20px;
+    font-size: 1em;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: background-color 0.3s ease;
+}
+
+.btn-primary {
+    background-color: #007bff;
+    color: white;
+}
+
+.btn-primary:hover {
+    background-color: #0056b3;
+}
+
+.btn-danger {
+    background-color: #dc3545;
+    color: white;
+}
+
+.btn-danger:hover {
+    background-color: #a71d2a;
+}

--- a/src/app/components/visual-stack-queue/visual-stack-queue.component.html
+++ b/src/app/components/visual-stack-queue/visual-stack-queue.component.html
@@ -1,0 +1,46 @@
+<!-- HTML: visual-stack-queue.component.html -->
+<app-navbar></app-navbar>
+
+<div class="container">
+    <div class="title">
+        <h1>Visual Stack and Queue</h1>
+    </div>
+
+    <div class="visual-container">
+        <!-- Stack Section -->
+        <div class="stack-container">
+            <h3><i class="fas fa-database"></i> Stack (DFS)</h3>
+            <div class="stack">
+                <div class="stack-item" *ngFor="let item of stack" [@stackAnimation]>
+                    {{ item }}
+                </div>
+            </div>
+            <div class="button-group">
+                <button class="btn btn-primary" (click)="addToStack('Node ' + (stack.length + 1))">
+                    <i class="fas fa-plus"></i> Add to Stack
+                </button>
+                <button class="btn btn-danger" (click)="removeFromStack()">
+                    <i class="fas fa-minus"></i> Remove from Stack
+                </button>
+            </div>
+        </div>
+
+        <!-- Queue Section -->
+        <div class="queue-container">
+            <h3><i class="fas fa-bars"></i> Queue (BFS)</h3>
+            <div class="queue">
+                <div class="queue-item" *ngFor="let item of queue" [@queueAnimation]>
+                    {{ item }}
+                </div>
+            </div>
+            <div class="button-group">
+                <button class="btn btn-primary" (click)="addToQueue('Node ' + (queue.length + 1))">
+                    <i class="fas fa-plus"></i> Add to Queue
+                </button>
+                <button class="btn btn-danger" (click)="removeFromQueue()">
+                    <i class="fas fa-minus"></i> Remove from Queue
+                </button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/app/components/visual-stack-queue/visual-stack-queue.component.spec.ts
+++ b/src/app/components/visual-stack-queue/visual-stack-queue.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { VisualStackQueueComponent } from './visual-stack-queue.component';
+
+describe('VisualStackQueueComponent', () => {
+  let component: VisualStackQueueComponent;
+  let fixture: ComponentFixture<VisualStackQueueComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [VisualStackQueueComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(VisualStackQueueComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/visual-stack-queue/visual-stack-queue.component.ts
+++ b/src/app/components/visual-stack-queue/visual-stack-queue.component.ts
@@ -1,0 +1,59 @@
+import { Component } from '@angular/core';
+import { trigger, state, style, transition, animate } from '@angular/animations';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common'; // Import CommonModule
+import { NavbarComponent } from '../navbar/navbar.component';
+
+@Component({
+  selector: 'app-visual-stack-queue',
+  standalone: true,
+  imports: [FormsModule, CommonModule, NavbarComponent], // Add CommonModule here
+  templateUrl: './visual-stack-queue.component.html',
+  styleUrls: ['./visual-stack-queue.component.css'],
+  animations: [
+    trigger('stackAnimation', [
+      transition(':enter', [
+        style({ transform: 'scale(0.5)', opacity: 0 }),
+        animate('300ms ease-out', style({ transform: 'scale(1)', opacity: 1 }))
+      ]),
+      transition(':leave', [
+        animate('300ms ease-in', style({ transform: 'scale(0.5)', opacity: 0 }))
+      ])
+    ]),
+    trigger('queueAnimation', [
+      transition(':enter', [
+        style({ transform: 'translateX(50%)', opacity: 0 }),
+        animate('300ms ease-out', style({ transform: 'translateX(0)', opacity: 1 }))
+      ]),
+      transition(':leave', [
+        animate('300ms ease-in', style({ transform: 'translateX(-50%)', opacity: 0 }))
+      ])
+    ])
+  ]
+})
+export class VisualStackQueueComponent {
+  stack: string[] = [];
+  queue: string[] = [];
+
+  constructor() {}
+
+  addToStack(item: string): void {
+    this.stack.push(item);
+  }
+
+  removeFromStack(): void {
+    if (this.stack.length > 0) {
+      this.stack.pop();
+    }
+  }
+
+  addToQueue(item: string): void {
+    this.queue.push(item);
+  }
+
+  removeFromQueue(): void {
+    if (this.queue.length > 0) {
+      this.queue.shift();
+    }
+  }
+}


### PR DESCRIPTION
fix: #542
Relation to DFS and BFS:
DFS (Depth-First Search):
DFS uses a stack (LIFO - Last In, First Out) to explore nodes.
In your component, the Stack (DFS) section visually represents how nodes are added to and removed from a stack.
DFS explores as far down one branch as possible before backtracking, mimicked by pushing and popping items from the stack.
BFS (Breadth-First Search):
BFS uses a queue (FIFO - First In, First Out) to explore nodes.
The Queue (BFS) section in your component shows how nodes are enqueued and dequeued.
BFS explores all nodes at the present depth level before moving to the next depth level, which is represented by the queue behavior.
recorded video: https://github.com/user-attachments/assets/04fcfb99-d0a6-45b5-9e41-a992f4584bf2


